### PR TITLE
Include transaction lists in Block and validate/apply them in Blockchain with chain-owned State

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -2,23 +2,25 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::transaction::SignedTransaction;
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Block {
     pub index: u64,
     pub timestamp: DateTime<Utc>,
-    pub data: String,
+    pub transactions: Vec<SignedTransaction>,
     pub previous_hash: String,
     pub hash: String,
 }
 
 impl Block {
-    pub fn new(index: u64, data: String, previous_hash: String) -> Self {
+    pub fn new(index: u64, transactions: Vec<SignedTransaction>, previous_hash: String) -> Self {
         let timestamp = Utc::now();
-        let hash = Self::calculate_hash(index, &timestamp, &data, &previous_hash);
+        let hash = Self::calculate_hash(index, &timestamp, &transactions, &previous_hash);
         Self {
             index,
             timestamp,
-            data,
+            transactions,
             previous_hash,
             hash,
         }
@@ -27,14 +29,14 @@ impl Block {
     pub fn calculate_hash(
         index: u64,
         timestamp: &DateTime<Utc>,
-        data: &str,
+        transactions: &[SignedTransaction],
         previous_hash: &str,
     ) -> String {
-        // Simple hash over fields (Json encoding)
+        // Deterministic hash over block header + full transaction list.
         let payload = serde_json::json!({
             "index": index,
             "timestamp": timestamp.to_rfc3339(),
-            "data": data,
+            "transactions": transactions,
             "previous_hash": previous_hash,
         })
         .to_string();

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1,21 +1,30 @@
 // src/blockchain.rs
 
 use crate::block::Block;
+use crate::state::State;
 
 #[derive(Debug)]
 pub struct Blockchain {
     pub chain: Vec<Block>,
+    pub state: State,
 }
 
 impl Blockchain {
     pub fn new() -> Self {
-        let mut bc = Blockchain { chain: Vec::new() };
+        Self::with_genesis_state(vec![])
+    }
+
+    pub fn with_genesis_state(genesis_balances: Vec<(String, u64)>) -> Self {
+        let mut bc = Blockchain {
+            chain: Vec::new(),
+            state: State::with_genesis(genesis_balances),
+        };
         bc.chain.push(Self::genesis_block());
         bc
     }
 
     fn genesis_block() -> Block {
-        Block::new(0, "Genesis Block".to_string(), "0".to_string())
+        Block::new(0, vec![], "0".to_string())
     }
 
     pub fn last_block(&self) -> &Block {
@@ -25,9 +34,9 @@ impl Blockchain {
     }
 
     /// Used by local miner / validator
-    pub fn add_block(&mut self, data: String) -> Block {
+    pub fn add_block(&mut self, transactions: Vec<crate::transaction::SignedTransaction>) -> Block {
         let last = self.last_block();
-        let new_block = Block::new(last.index + 1, data, last.hash.clone());
+        let new_block = Block::new(last.index + 1, transactions, last.hash.clone());
         self.chain.push(new_block.clone());
         new_block
     }
@@ -47,7 +56,7 @@ impl Blockchain {
         let recalculated = Block::calculate_hash(
             block.index,
             &block.timestamp,
-            &block.data,
+            &block.transactions,
             &block.previous_hash,
         );
 
@@ -55,7 +64,18 @@ impl Blockchain {
             return Err("Invalid block hash".into());
         }
 
+        let mut next_state = self.state.clone();
+        for tx in &block.transactions {
+            next_state
+                .validate_transaction(tx)
+                .map_err(|e| format!("Invalid transaction in block: {e:?}"))?;
+            next_state
+                .apply_transaction(tx)
+                .map_err(|e| format!("Failed to apply transaction in block: {e:?}"))?;
+        }
+
         self.chain.push(block);
+        self.state = next_state;
         Ok(())
     }
 
@@ -71,7 +91,7 @@ impl Blockchain {
             let recalculated = Block::calculate_hash(
                 current.index,
                 &current.timestamp,
-                &current.data,
+                &current.transactions,
                 &current.previous_hash,
             );
 
@@ -80,5 +100,96 @@ impl Blockchain {
             }
         }
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transaction::{
+        generate_ed25519_keypair, pubkey_to_address_hex, SignedTransaction, Transaction,
+    };
+
+    fn make_signed_tx(
+        sender_key: &crate::transaction::KeyPair,
+        receiver: &str,
+        amount: u64,
+        fee: u64,
+        nonce: u64,
+    ) -> SignedTransaction {
+        let sender = pubkey_to_address_hex(&sender_key.public);
+        let tx = Transaction::new(sender, receiver.to_string(), amount, fee, nonce, None);
+        SignedTransaction::sign_with_keypair(&tx, sender_key)
+    }
+
+    #[test]
+    fn valid_block_with_valid_tx_list() {
+        let sender_kp = generate_ed25519_keypair();
+        let sender = pubkey_to_address_hex(&sender_kp.public);
+
+        let mut bc = Blockchain::with_genesis_state(vec![(sender.clone(), 1_000)]);
+        let tx = make_signed_tx(&sender_kp, "receiver", 100, 1, 0);
+        let block = Block::new(1, vec![tx], bc.last_block().hash.clone());
+
+        assert!(bc.validate_and_add_block(block).is_ok());
+        assert_eq!(bc.chain.len(), 2);
+        assert_eq!(bc.state.get_balance(&sender), 899);
+        assert_eq!(bc.state.get_balance("receiver"), 100);
+        assert_eq!(bc.state.get_nonce(&sender), 1);
+    }
+
+    #[test]
+    fn block_rejected_on_invalid_signature() {
+        let sender_kp = generate_ed25519_keypair();
+        let sender = pubkey_to_address_hex(&sender_kp.public);
+
+        let mut bc = Blockchain::with_genesis_state(vec![(sender, 1_000)]);
+        let mut tx = make_signed_tx(&sender_kp, "receiver", 100, 1, 0);
+        tx.signature = "definitely-not-valid-base64-signature".to_string();
+
+        let block = Block::new(1, vec![tx], bc.last_block().hash.clone());
+        let result = bc.validate_and_add_block(block);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Invalid transaction in block: InvalidSignature"));
+        assert_eq!(bc.chain.len(), 1);
+    }
+
+    #[test]
+    fn block_rejected_on_nonce_mismatch() {
+        let sender_kp = generate_ed25519_keypair();
+        let sender = pubkey_to_address_hex(&sender_kp.public);
+
+        let mut bc = Blockchain::with_genesis_state(vec![(sender, 1_000)]);
+        let tx = make_signed_tx(&sender_kp, "receiver", 100, 1, 5);
+
+        let block = Block::new(1, vec![tx], bc.last_block().hash.clone());
+        let result = bc.validate_and_add_block(block);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Invalid transaction in block: InvalidNonce"));
+        assert_eq!(bc.chain.len(), 1);
+    }
+
+    #[test]
+    fn block_rejected_on_insufficient_balance() {
+        let sender_kp = generate_ed25519_keypair();
+        let sender = pubkey_to_address_hex(&sender_kp.public);
+
+        let mut bc = Blockchain::with_genesis_state(vec![(sender, 50)]);
+        let tx = make_signed_tx(&sender_kp, "receiver", 100, 1, 0);
+
+        let block = Block::new(1, vec![tx], bc.last_block().hash.clone());
+        let result = bc.validate_and_add_block(block);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Invalid transaction in block: InsufficientBalance"));
+        assert_eq!(bc.chain.len(), 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 mod block;
 mod blockchain;
 mod p2p;
+mod state;
+mod transaction;
 
 use anyhow::Result;
 use std::sync::Arc;
@@ -49,7 +51,7 @@ async fn main() -> Result<()> {
 
         let block = {
             let mut bc = blockchain_broadcast.lock().await;
-            bc.add_block("Hello from NetChain".to_string())
+            bc.add_block(vec![])
         };
 
         let json = serde_json::to_string(&block).unwrap();


### PR DESCRIPTION
### Motivation
- Replace the simple free-form `data` field with a structured transaction list so blocks carry executable ledger operations.
- Ensure block hashes reflect the full deterministic contents of the transaction list for reproducible validation.
- Enforce transaction-level validation and state updates when accepting blocks so chain acceptance is atomic and consistent with account state.

### Description
- Replaced `Block.data: String` with `Block.transactions: Vec<SignedTransaction>` and updated `Block::new` and `Block::calculate_hash` to include a deterministic representation of transactions (`src/block.rs`).
- Added a chain-owned `state: State` to `Blockchain`, provided `with_genesis_state` for genesis initialization, and updated `genesis_block` to use an empty transaction list (`src/blockchain.rs`).
- Extended `validate_and_add_block` to (1) recalculate the hash over `transactions`, (2) clone the current `state`, (3) validate each transaction via `State::validate_transaction` and apply them in order via `State::apply_transaction`, and (4) commit the new `state` only if all transactions succeed (`src/blockchain.rs`).
- Adjusted `add_block` API and updated the local binary wiring to include `state`/`transaction` modules and to construct blocks with a `Vec<SignedTransaction>` (`src/main.rs`).
- Added unit tests to `src/blockchain.rs` covering a valid block with transactions and rejection cases for invalid signature, nonce mismatch, and insufficient balance.

### Testing
- Ran `cargo fmt` to format changes successfully.
- Ran `cargo test` and all unit tests passed; the new `blockchain` tests for: valid tx list, invalid signature, nonce mismatch, and insufficient balance all succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59eed1d68832798a56a4470a0036e)