### PR TITLE
Add persistent chain/state storage with startup recovery and integrity checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1812,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "bincode",
  "chrono",
  "ed25519-dalek",
  "libp2p",
@@ -2927,6 +2948,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +2987,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,5 @@ libp2p = { version = "0.56", features = [
 rand = "0.8"
 base64 = "0.22"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
+
+bincode = { version = "2.0", features = ["serde"] }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -2,7 +2,7 @@
 
 use crate::block::Block;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Blockchain {
     pub chain: Vec<Block>,
 }
@@ -12,6 +12,23 @@ impl Blockchain {
         let mut bc = Blockchain { chain: Vec::new() };
         bc.chain.push(Self::genesis_block());
         bc
+    }
+
+    pub fn from_chain(chain: Vec<Block>) -> Result<Self, String> {
+        if chain.is_empty() {
+            return Err("Loaded chain is empty".into());
+        }
+
+        let bc = Self { chain };
+        if bc.chain[0].index != 0 || bc.chain[0].previous_hash != "0" {
+            return Err("Invalid genesis block".into());
+        }
+
+        if !bc.is_valid() {
+            return Err("Loaded chain failed validation".into());
+        }
+
+        Ok(bc)
     }
 
     fn genesis_block() -> Block {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub mod consensus;
 pub mod mempool;
 pub mod p2p;
 pub mod state;
+pub mod storage;
 pub mod transaction;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,9 @@
 mod block;
 mod blockchain;
 mod p2p;
+mod state;
+mod storage;
+mod transaction;
 
 use anyhow::Result;
 use std::sync::Arc;
@@ -12,16 +15,53 @@ use tokio::time::{sleep, Duration};
 use block::Block;
 use blockchain::Blockchain;
 use p2p::{NetworkMessage, P2PEvent, P2PService};
+use state::State;
+use storage::Storage;
+
+const SNAPSHOT_INTERVAL: usize = 5;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     println!("⚡ Starting NetChain (development mode)");
 
-    // Shared blockchain state
-    let blockchain = Arc::new(Mutex::new(Blockchain::new()));
+    let storage = Storage::new("data");
+
+    let chain = match storage.load_chain() {
+        Ok(Some(chain)) => {
+            println!("💾 Loaded persisted chain with height {}", chain.len() - 1);
+            Blockchain::from_chain(chain).map_err(anyhow::Error::msg)?
+        }
+        Ok(None) => {
+            println!("🆕 No persisted chain found. Initializing genesis chain.");
+            Blockchain::new()
+        }
+        Err(e) => {
+            println!("⚠️ Failed to load persisted chain ({e}). Initializing genesis chain.");
+            Blockchain::new()
+        }
+    };
+
+    let state = match storage.load_state_snapshot() {
+        Ok(Some((state, height))) => {
+            println!("💾 Loaded state snapshot at height {height}");
+            state
+        }
+        Ok(None) => {
+            println!("🆕 No persisted state snapshot found. Starting empty state.");
+            State::new()
+        }
+        Err(e) => {
+            println!("⚠️ Failed to load state snapshot ({e}). Starting empty state.");
+            State::new()
+        }
+    };
+
+    let blockchain = Arc::new(Mutex::new(chain));
+    let state = Arc::new(Mutex::new(state));
+
     {
         let bc = blockchain.lock().await;
-        println!("Genesis block: {:?}", bc.last_block());
+        println!("Current tip: {:?}", bc.last_block());
     }
 
     // Channel: P2P → main
@@ -42,6 +82,8 @@ async fn main() -> Result<()> {
     // 🔥 TEMPORARY: create & broadcast a block after 10 seconds
     let p2p_broadcast = p2p.clone();
     let blockchain_broadcast = blockchain.clone();
+    let state_broadcast = state.clone();
+    let storage_broadcast = storage.clone();
     tokio::spawn(async move {
         sleep(Duration::from_secs(10)).await;
 
@@ -49,7 +91,22 @@ async fn main() -> Result<()> {
 
         let block = {
             let mut bc = blockchain_broadcast.lock().await;
-            bc.add_block("Hello from NetChain".to_string())
+            let block = bc.add_block("Hello from NetChain".to_string());
+
+            if let Err(e) = storage_broadcast.persist_chain(&bc.chain) {
+                println!("⚠️ Failed to persist chain after local block: {e}");
+            }
+
+            if (bc.chain.len() - 1) % SNAPSHOT_INTERVAL == 0 {
+                let state_guard = state_broadcast.lock().await;
+                if let Err(e) =
+                    storage_broadcast.persist_state_snapshot(&state_guard, bc.chain.len() - 1)
+                {
+                    println!("⚠️ Failed to persist state snapshot: {e}");
+                }
+            }
+
+            block
         };
 
         let json = serde_json::to_string(&block).unwrap();
@@ -72,6 +129,19 @@ async fn main() -> Result<()> {
                         match bc.validate_and_add_block(block) {
                             Ok(_) => {
                                 println!("✅ Block accepted. Chain height: {}", bc.chain.len() - 1);
+
+                                if let Err(e) = storage.persist_chain(&bc.chain) {
+                                    println!("⚠️ Failed to persist chain: {e}");
+                                }
+
+                                if (bc.chain.len() - 1) % SNAPSHOT_INTERVAL == 0 {
+                                    let state_guard = state.lock().await;
+                                    if let Err(e) = storage
+                                        .persist_state_snapshot(&state_guard, bc.chain.len() - 1)
+                                    {
+                                        println!("⚠️ Failed to persist state snapshot: {e}");
+                                    }
+                                }
                             }
                             Err(e) => {
                                 println!("❌ Block rejected: {e}");

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
 use crate::transaction::{SignedTransaction, Transaction};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Errors that can occur during state transitions.
@@ -12,7 +13,7 @@ pub enum StateError {
 }
 
 /// Account state.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Account {
     pub balance: u64,
     pub nonce: u64,
@@ -25,7 +26,7 @@ impl Account {
 }
 
 /// Global chain state (ledger).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct State {
     /// address -> account
     accounts: HashMap<String, Account>,
@@ -44,6 +45,14 @@ impl State {
             accounts.insert(addr, Account::new(balance));
         }
         Self { accounts }
+    }
+
+    pub fn from_accounts(accounts: HashMap<String, Account>) -> Self {
+        Self { accounts }
+    }
+
+    pub fn snapshot_accounts(&self) -> HashMap<String, Account> {
+        self.accounts.clone()
     }
 
     pub fn get_balance(&self, address: &str) -> u64 {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,209 @@
+use crate::block::Block;
+use crate::blockchain::Blockchain;
+use crate::state::{Account, State};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CHAIN_FILE: &str = "chain.json";
+const STATE_FILE: &str = "state_snapshot.bin";
+
+#[derive(Debug, Clone)]
+pub struct Storage {
+    base_dir: PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedBlockRecord {
+    block: Block,
+    checksum: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedStateSnapshot {
+    height: usize,
+    accounts: HashMap<String, Account>,
+}
+
+impl Storage {
+    pub fn new(base_dir: impl AsRef<Path>) -> Self {
+        Self {
+            base_dir: base_dir.as_ref().to_path_buf(),
+        }
+    }
+
+    pub fn persist_chain(&self, chain: &[Block]) -> Result<(), String> {
+        fs::create_dir_all(&self.base_dir).map_err(|e| format!("failed creating base dir: {e}"))?;
+
+        let records: Vec<PersistedBlockRecord> = chain
+            .iter()
+            .cloned()
+            .map(|block| PersistedBlockRecord {
+                checksum: block_checksum(&block),
+                block,
+            })
+            .collect();
+
+        let bytes = serde_json::to_vec_pretty(&records)
+            .map_err(|e| format!("failed serializing chain: {e}"))?;
+
+        fs::write(self.chain_path(), bytes).map_err(|e| format!("failed writing chain file: {e}"))
+    }
+
+    pub fn load_chain(&self) -> Result<Option<Vec<Block>>, String> {
+        let path = self.chain_path();
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let bytes = fs::read(path).map_err(|e| format!("failed reading chain file: {e}"))?;
+        let records: Vec<PersistedBlockRecord> =
+            serde_json::from_slice(&bytes).map_err(|e| format!("failed parsing chain: {e}"))?;
+
+        let mut chain = Vec::with_capacity(records.len());
+        for record in records {
+            let actual = block_checksum(&record.block);
+            if record.checksum != actual {
+                return Err("persisted block checksum mismatch".into());
+            }
+            chain.push(record.block);
+        }
+
+        Blockchain::from_chain(chain.clone())
+            .map_err(|e| format!("loaded chain failed validation: {e}"))?;
+
+        Ok(Some(chain))
+    }
+
+    pub fn persist_state_snapshot(&self, state: &State, height: usize) -> Result<(), String> {
+        fs::create_dir_all(&self.base_dir).map_err(|e| format!("failed creating base dir: {e}"))?;
+
+        let snapshot = PersistedStateSnapshot {
+            height,
+            accounts: state.snapshot_accounts(),
+        };
+
+        let bytes = bincode::serde::encode_to_vec(&snapshot, bincode::config::standard())
+            .map_err(|e| format!("failed serializing snapshot: {e}"))?;
+
+        fs::write(self.state_path(), bytes).map_err(|e| format!("failed writing snapshot: {e}"))
+    }
+
+    pub fn load_state_snapshot(&self) -> Result<Option<(State, usize)>, String> {
+        let path = self.state_path();
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let bytes = fs::read(path).map_err(|e| format!("failed reading snapshot: {e}"))?;
+        let (snapshot, _): (PersistedStateSnapshot, usize) =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::standard())
+                .map_err(|e| format!("failed decoding snapshot: {e}"))?;
+
+        Ok(Some((
+            State::from_accounts(snapshot.accounts),
+            snapshot.height,
+        )))
+    }
+
+    pub fn chain_path(&self) -> PathBuf {
+        self.base_dir.join(CHAIN_FILE)
+    }
+
+    pub fn state_path(&self) -> PathBuf {
+        self.base_dir.join(STATE_FILE)
+    }
+}
+
+fn block_checksum(block: &Block) -> String {
+    let bytes = serde_json::to_vec(block).expect("block serialization should succeed");
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_dir(name: &str) -> PathBuf {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("netchain_{name}_{ts}"))
+    }
+
+    #[test]
+    fn round_trip_save_load_chain_and_state() {
+        let dir = test_dir("round_trip");
+        let storage = Storage::new(&dir);
+
+        let mut bc = Blockchain::new();
+        bc.add_block("one".into());
+        bc.add_block("two".into());
+
+        let state = State::with_genesis(vec![("alice".to_string(), 42)]);
+
+        storage.persist_chain(&bc.chain).expect("persist chain");
+        storage
+            .persist_state_snapshot(&state, bc.chain.len() - 1)
+            .expect("persist state");
+
+        let loaded_chain = storage
+            .load_chain()
+            .expect("load chain")
+            .expect("chain exists");
+        let (loaded_state, height) = storage
+            .load_state_snapshot()
+            .expect("load state")
+            .expect("state exists");
+
+        assert_eq!(loaded_chain.len(), bc.chain.len());
+        assert_eq!(
+            loaded_chain.last().unwrap().hash,
+            bc.chain.last().unwrap().hash
+        );
+        assert_eq!(height, bc.chain.len() - 1);
+        assert_eq!(loaded_state.get_balance("alice"), 42);
+    }
+
+    #[test]
+    fn rejects_corrupted_chain_data() {
+        let dir = test_dir("checksum");
+        let storage = Storage::new(&dir);
+
+        let mut bc = Blockchain::new();
+        bc.add_block("valid".into());
+        storage.persist_chain(&bc.chain).expect("persist chain");
+
+        let mut bytes = fs::read(storage.chain_path()).expect("read chain file");
+        bytes.push(b'!');
+        fs::write(storage.chain_path(), bytes).expect("corrupt chain file");
+
+        assert!(storage.load_chain().is_err());
+    }
+
+    #[test]
+    fn restart_continuity_uses_loaded_chain() {
+        let dir = test_dir("restart");
+        let storage = Storage::new(&dir);
+
+        let mut first = Blockchain::new();
+        first.add_block("before restart".into());
+        storage.persist_chain(&first.chain).expect("persist chain");
+
+        let loaded = storage
+            .load_chain()
+            .expect("load chain")
+            .expect("chain exists");
+        let mut restarted = Blockchain::from_chain(loaded).expect("valid loaded chain");
+
+        restarted.add_block("after restart".into());
+        assert_eq!(restarted.chain.len(), 3);
+        assert_eq!(restarted.last_block().index, 2);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide durable, file-backed persistence for the chain and state so the node can recover across restarts.
- Ensure on-disk data integrity by detecting corrupted blocks and rejecting invalid persisted data.
- Periodically snapshot ledger state to reduce recovery cost and enable restart continuity.

### Description
- Add a new persistence module `src/storage.rs` that writes the chain as JSON (`chain.json`) with per-block SHA-256 checksums and writes state snapshots as bincode (`state_snapshot.bin`).
- Validate checksums when loading the chain and re-run structural/hash validation via a new `Blockchain::from_chain` constructor to reject corrupted/invalid files.
- Integrate persistence into `src/main.rs` to load persisted chain/state at startup (falling back to genesis/empty state on absence or load failure), persist the chain on every appended/accepted block, and create periodic state snapshots (controlled via `SNAPSHOT_INTERVAL`).
- Extend `src/state.rs` with serde derives and helpers (`from_accounts`, `snapshot_accounts`) to enable serializing/deserializing state snapshots.
- Export the new module in `src/lib.rs` and add `bincode` dependency to `Cargo.toml` for binary snapshot encoding.
- Add unit tests in `src/storage.rs` covering round-trip save/load, corrupted-chain rejection, and restart continuity.

### Testing
- Ran `cargo test`, which completed successfully with all unit tests passing (storage-specific tests `round_trip_save_load_chain_and_state`, `rejects_corrupted_chain_data`, and `restart_continuity_uses_loaded_chain` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59f43ee8c8327b59831b18f3299c9)