### PR TITLE
Add configurable periodic block proposer loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,17 @@
 
 mod block;
 mod blockchain;
+mod mempool;
 mod p2p;
+mod state;
+mod transaction;
 
 use anyhow::Result;
+use mempool::Mempool;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
-use tokio::time::{sleep, Duration};
+use tokio::time::{interval, Duration};
+use transaction::SignedTransaction;
 
 use block::Block;
 use blockchain::Blockchain;
@@ -19,6 +24,7 @@ async fn main() -> Result<()> {
 
     // Shared blockchain state
     let blockchain = Arc::new(Mutex::new(Blockchain::new()));
+    let mempool = Arc::new(Mutex::new(Mempool::new()));
     {
         let bc = blockchain.lock().await;
         println!("Genesis block: {:?}", bc.last_block());
@@ -39,26 +45,97 @@ async fn main() -> Result<()> {
 
     println!("Node running on port {port}. Waiting for P2P events...\n");
 
-    // 🔥 TEMPORARY: create & broadcast a block after 10 seconds
-    let p2p_broadcast = p2p.clone();
-    let blockchain_broadcast = blockchain.clone();
-    tokio::spawn(async move {
-        sleep(Duration::from_secs(10)).await;
+    let proposer_enabled = std::env::var("NETCHAIN_ENABLE_PROPOSER")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false);
+    let proposer_interval_secs = std::env::var("NETCHAIN_PROPOSER_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|secs| (2..=5).contains(secs))
+        .unwrap_or(3);
 
-        println!("⛏️ Creating new block locally...");
+    if proposer_enabled {
+        let p2p_proposer = p2p.clone();
+        let blockchain_proposer = blockchain.clone();
+        let mempool_proposer = mempool.clone();
 
-        let block = {
-            let mut bc = blockchain_broadcast.lock().await;
-            bc.add_block("Hello from NetChain".to_string())
-        };
+        tokio::spawn(async move {
+            let mut ticker = interval(Duration::from_secs(proposer_interval_secs));
+            let max_txs = 100usize;
 
-        let json = serde_json::to_string(&block).unwrap();
+            println!(
+                "⛏️ Proposer enabled (interval={}s, max_txs={max_txs})",
+                proposer_interval_secs
+            );
 
-        let mut p2p = p2p_broadcast.lock().await;
-        p2p.publish_block(json);
+            loop {
+                ticker.tick().await;
+                println!("⏱️ Proposer tick");
 
-        println!("📡 Block broadcasted");
-    });
+                let selected_txs = {
+                    let mempool = mempool_proposer.lock().await;
+                    mempool.select_for_block(max_txs)
+                };
+
+                println!("📥 Selected {} tx(s) for proposal", selected_txs.len());
+
+                if selected_txs.is_empty() {
+                    println!("⏭️ Skipping proposal: mempool is empty");
+                    continue;
+                }
+
+                let payload = selected_txs
+                    .iter()
+                    .map(SignedTransaction::tx_hash_hex)
+                    .collect::<Vec<_>>()
+                    .join(",");
+
+                let maybe_block = {
+                    let bc = blockchain_proposer.lock().await;
+                    let last = bc.last_block();
+                    let candidate_block =
+                        Block::new(last.index + 1, format!("txs:{payload}"), last.hash.clone());
+
+                    if candidate_block.previous_hash != last.hash {
+                        println!("❌ Proposal failed local validation: invalid previous hash");
+                        None
+                    } else {
+                        Some(candidate_block)
+                    }
+                };
+
+                let Some(block) = maybe_block else {
+                    continue;
+                };
+
+                {
+                    let mut bc = blockchain_proposer.lock().await;
+                    if let Err(e) = bc.validate_and_add_block(block.clone()) {
+                        println!("❌ Failed to append proposed block locally: {e}");
+                        continue;
+                    }
+                }
+
+                {
+                    let mut mempool = mempool_proposer.lock().await;
+                    mempool.remove_transactions(&selected_txs);
+                }
+
+                match serde_json::to_string(&block) {
+                    Ok(json) => {
+                        let mut p2p = p2p_proposer.lock().await;
+                        p2p.publish_block(json);
+                        println!("✅ Proposal succeeded: block {} broadcasted", block.index);
+                    }
+                    Err(e) => {
+                        println!("❌ Proposal failed serialization: {e}");
+                    }
+                }
+            }
+        });
+    } else {
+        println!("⏸️ Proposer disabled (set NETCHAIN_ENABLE_PROPOSER=true to enable)");
+    }
 
     // Main event loop
     while let Some(event) = rx.recv().await {
@@ -83,7 +160,6 @@ async fn main() -> Result<()> {
                     }
                 }
             }
-
             P2PEvent::Message(NetworkMessage::Transaction(tx)) => {
                 println!("💸 Received transaction (not yet handled): {tx}");
             }


### PR DESCRIPTION
### Motivation
- Replace the temporary one-shot 10s broadcast with a repeatable proposer flow for local development and testing. 
- Drive proposals from real mempool candidates instead of broadcasting a fixed payload.
- Avoid spamming empty blocks when the mempool is empty and provide clear operational logs.
- Allow enabling/disabling proposers so not all local nodes propose simultaneously during tests.

### Description
- Removed the hardcoded one-shot task and added a configurable periodic proposer task in `src/main.rs` driven by env flags `NETCHAIN_ENABLE_PROPOSER` and `NETCHAIN_PROPOSER_INTERVAL_SECS` (clamped to 2–5s, default `3`).
- Created and wired a shared `Mempool` instance in `main` and on each tick the proposer calls `Mempool::select_for_block` to pick candidate transactions (up to `max_txs`).
- Constructed a `Block` candidate via `Block::new(...)`, performed local validation with `Blockchain::validate_and_add_block`, appended the block locally when valid, removed included txs from the mempool, and published block JSON via `P2PService::publish_block`.
- Implemented graceful handling for empty mempool by skipping the proposal tick (no empty spam blocks), and added explicit logs for proposer enabled/disabled state, each tick, selected tx count, skip-on-empty, local validation/append failures, serialization failures, and successful broadcasts.

### Testing
- Ran formatting and static checks with `cargo fmt --all && cargo check` which completed successfully.
- `cargo check` produced only warning-level diagnostics (dead-code / unused items) unrelated to this change and no compilation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59f425ac8832781f10aa74ccc0f66)